### PR TITLE
Added contact properties to Send event action

### DIFF
--- a/packages/destination-actions/src/destinations/loops/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/loops/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -29,6 +29,7 @@ Object {
   "eventProperties": Object {
     "testType": "aeKHha#$d",
   },
+  "testType": "aeKHha#$d",
   "userId": "aeKHha#$d",
 }
 `;

--- a/packages/destination-actions/src/destinations/loops/sendEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/loops/sendEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,6 +7,7 @@ Object {
   "eventProperties": Object {
     "testType": "gJCx1dPfi6rH2R",
   },
+  "testType": "gJCx1dPfi6rH2R",
   "userId": "gJCx1dPfi6rH2R",
 }
 `;

--- a/packages/destination-actions/src/destinations/loops/sendEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/loops/sendEvent/generated-types.ts
@@ -19,4 +19,10 @@ export interface Payload {
   eventProperties?: {
     [k: string]: unknown
   }
+  /**
+   * Contact properties that can will be updated on this contact.
+   */
+  contactProperties?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/loops/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/loops/sendEvent/index.ts
@@ -39,6 +39,12 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.userId'
       }
     },
+    contactProperties: {
+      label: 'Contact Properties',
+      description: "Optional properties that will be updated on the event's contact.",
+      type: 'object',
+      required: false
+    },
     eventProperties: {
       label: 'Event Properties',
       description: 'Event-specific properties that can be included in emails triggered by this event.',
@@ -54,7 +60,8 @@ const action: ActionDefinition<Settings, Payload> = {
         email: payload.email,
         eventName: payload.eventName,
         userId: payload.userId,
-        eventProperties: payload.eventProperties
+        eventProperties: payload.eventProperties,
+        ...(typeof payload.contactProperties === 'object' && payload.contactProperties)
       }
     })
   }


### PR DESCRIPTION
Add ability to sync contact data with "Send event" calls, similarly to how the API works.

Uses a dummy "Contact properties" object like the "createOrUpdateContact" action.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
